### PR TITLE
master_EBE_3851_application_boxes_deployment_fails

### DIFF
--- a/src/main/java/com/elasticbox/jenkins/model/repository/api/serializer/deployment/ApplicationBoxDeploymentSerializer.java
+++ b/src/main/java/com/elasticbox/jenkins/model/repository/api/serializer/deployment/ApplicationBoxDeploymentSerializer.java
@@ -53,7 +53,7 @@ public class ApplicationBoxDeploymentSerializer
             ApplicationBoxDeploymentRequestObject.class, new PropertyNameProcessor() {
                 @Override
                 public String processPropertyName(Class beanClass, String name) {
-                    if(name.equals("instanceTags")) {
+                    if (name.equals("instanceTags")) {
                         return "instance_tags";
                     }
                     return name;

--- a/src/main/java/com/elasticbox/jenkins/model/repository/api/serializer/deployment/ApplicationBoxDeploymentSerializer.java
+++ b/src/main/java/com/elasticbox/jenkins/model/repository/api/serializer/deployment/ApplicationBoxDeploymentSerializer.java
@@ -50,11 +50,10 @@ public class ApplicationBoxDeploymentSerializer
 
         JsonConfig jsonConfig = new JsonConfig();
         jsonConfig.registerJsonPropertyNameProcessor(
-            ApplicationBoxDeploymentRequestObject.class,
-            new PropertyNameProcessor() {
+            ApplicationBoxDeploymentRequestObject.class, new PropertyNameProcessor() {
                 @Override
                 public String processPropertyName(Class beanClass, String name) {
-                    if(name.equals("instanceTags")){
+                    if(name.equals("instanceTags")) {
                         return "instance_tags";
                     }
                     return name;

--- a/src/main/java/com/elasticbox/jenkins/model/repository/api/serializer/deployment/ApplicationBoxDeploymentSerializer.java
+++ b/src/main/java/com/elasticbox/jenkins/model/repository/api/serializer/deployment/ApplicationBoxDeploymentSerializer.java
@@ -18,6 +18,8 @@ import com.elasticbox.Constants;
 import com.elasticbox.jenkins.model.services.deployment.execution.context.ApplicationBoxDeploymentContext;
 import com.elasticbox.jenkins.model.services.deployment.execution.order.ApplicationBoxDeploymentOrder;
 import net.sf.json.JSONObject;
+import net.sf.json.JsonConfig;
+import net.sf.json.processors.PropertyNameProcessor;
 import org.apache.commons.lang.StringUtils;
 
 public class ApplicationBoxDeploymentSerializer
@@ -46,7 +48,21 @@ public class ApplicationBoxDeploymentSerializer
                         box,
                         lease);
 
-        return JSONObject.fromObject(applicationBoxDeploymentRequestObject);
+        JsonConfig jsonConfig = new JsonConfig();
+        jsonConfig.registerJsonPropertyNameProcessor(
+            ApplicationBoxDeploymentRequestObject.class,
+            new PropertyNameProcessor() {
+                @Override
+                public String processPropertyName(Class beanClass, String name) {
+                    if(name.equals("instanceTags")){
+                        return "instance_tags";
+                    }
+                    return name;
+                }
+            }
+        );
+
+        return JSONObject.fromObject(applicationBoxDeploymentRequestObject, jsonConfig);
     }
 
 

--- a/src/main/java/com/elasticbox/jenkins/triggers/github/PullRequestData.java
+++ b/src/main/java/com/elasticbox/jenkins/triggers/github/PullRequestData.java
@@ -67,6 +67,7 @@ public class PullRequestData {
             return false;
         }
         if (pullRequest.getUpdatedAt().compareTo(lastUpdated) <= 0) {
+
             return false;
         }
 

--- a/src/test/java/com/elasticbox/jenkins/model/repository/api/serializer/deployment/TestApplicationBoxDeploymentSerializer.java
+++ b/src/test/java/com/elasticbox/jenkins/model/repository/api/serializer/deployment/TestApplicationBoxDeploymentSerializer.java
@@ -56,7 +56,7 @@ public class TestApplicationBoxDeploymentSerializer {
         assertTrue("policyBox id was not set", request.getJSONObject("lease").getString("expire").equals(expiration.getUtcDateTime()));
         assertTrue("policyBox id was not set", request.getJSONObject("lease").getString("operation").equals("terminate"));
         assertTrue("policyBox id was not set", request.getJSONObject("box").getString("id").equals("FAKE_BOX_ID"));
-        assertTrue("policyBox id was not set", request.getJSONArray("instanceTags").get(0).equals("FAKE_TAG"));
+        assertTrue("policyBox id was not set", request.getJSONArray("instance_tags").get(0).equals("FAKE_TAG"));
         assertTrue("policyBox id was not set", request.getJSONArray("requirements").get(0).equals("FAKE_CLAIM"));
         assertTrue("policyBox id was not set", request.getString("schema").equals("http://elasticbox.net/schemas/deploy/application"));
         assertTrue("policyBox id was not set", request.getString("owner").equals("FAKE_OWNER"));


### PR DESCRIPTION
The application box deployments fails because a non valid attribute in the request JSON. That attr wasn't validated before but now it is, so it fails
